### PR TITLE
Run check-dist on all PRs, even .MDs, since required

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -12,8 +12,6 @@ on:
     paths-ignore:
       - "**.md"
   pull_request:
-    paths-ignore:
-      - "**.md"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This is is a required step for PRs to be merged/accepted.  Running it even on *.MD files may feel goofy and wasteful, but it's the path of least resistance.

---

# Things!
## Excitement!
[Links!](https://google.ca)
`Markdown!`